### PR TITLE
Dashboard: iOS Farm / by Handler top bar + Agniverse footer

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "@git-agni/phone-farm-core",
       "version": "0.1.0-review.0",
+      "license": "Apache-2.0",
       "dependencies": {
         "@fastify/cookie": "^11.1.2",
         "@fastify/formbody": "^8.0.2",

--- a/src/api/app.ts
+++ b/src/api/app.ts
@@ -75,7 +75,7 @@ function escapeHtml(value: unknown): string {
 
 // Shown at the foot of every dashboard page. Override the link with
 // PHONE_FARM_BRAND_URL; the text is fixed.
-const FOOTER_HTML = `Built by <a href="${escapeHtml(process.env.PHONE_FARM_BRAND_URL ?? 'https://agniverse.co')}" target="_blank" rel="noopener">Agni</a> with love and curry`;
+const FOOTER_HTML = `Built by <a href="${escapeHtml(process.env.PHONE_FARM_BRAND_URL ?? 'https://agniverse.co')}" target="_blank" rel="noopener">Agniverse</a>, with love and curry &#10084;&#65039;`;
 
 function page(title: string, body: string, logoutPath?: string, navLinks: readonly PluginNavLink[] = []): string {
     const logout = logoutPath ? `<a href="${escapeHtml(logoutPath)}" style="float:right;margin-right:0">Log out</a>` : '';

--- a/static/dashboard/styles.css
+++ b/static/dashboard/styles.css
@@ -22,7 +22,17 @@ h1, h2, p { margin-top: 0; }
 h1 { margin-bottom: 8px; font-size: clamp(34px, 6vw, 58px); line-height: 1; letter-spacing: -.055em; }
 h2 { margin-bottom: 7px; font-size: 20px; letter-spacing: -.02em; }
 p { margin-bottom: 0; color: var(--muted); line-height: 1.55; }
-.shell { width: min(1060px, calc(100% - 32px)); margin: 0 auto; padding: 58px 0 80px; }
+.shell { width: min(1060px, calc(100% - 32px)); margin: 0 auto; padding: 36px 0 80px; }
+.topbar { position: sticky; top: 0; z-index: 60; border-bottom: 1px solid var(--border); background: rgb(8 11 16 / 84%); backdrop-filter: blur(14px); -webkit-backdrop-filter: blur(14px); }
+.topbar-inner { display: flex; align-items: center; justify-content: space-between; gap: 18px; width: min(1060px, calc(100% - 32px)); margin: 0 auto; padding: 9px 0; }
+.brand { display: flex; flex-direction: column; line-height: 1.2; }
+.brand-name { font-size: 17px; font-weight: 800; letter-spacing: -.02em; text-decoration: none; }
+.brand-by { color: var(--muted); font-size: 11px; font-weight: 650; letter-spacing: .02em; text-decoration: none; }
+.brand-by:hover { color: var(--text); }
+.topbar-nav { display: flex; flex-wrap: wrap; justify-content: flex-end; align-items: center; gap: 7px; }
+.topbar-nav .button { min-height: 34px; padding: 0 12px; font-size: 12px; }
+.topbar-nav .crumb { color: #778294; font-size: 13px; text-decoration: none; margin: 0 4px; }
+.topbar-nav .crumb:hover { color: var(--text); }
 .app-footer { width: min(1060px, calc(100% - 32px)); margin: -48px auto 28px; color: #5b6675; font-size: 12px; text-align: center; }
 .app-footer a { color: #7c8797; text-decoration: none; }
 .app-footer a:hover { color: var(--text); }

--- a/static/dashboard/templates/device.html
+++ b/static/dashboard/templates/device.html
@@ -8,18 +8,25 @@
     <script src="/assets/htmx.min.js" defer></script>
 </head>
 <body>
-    <main class="shell device-shell" data-device-udid="__DEVICE_UDID__">
-        <nav class="breadcrumb">
-            <a href="/">Devices</a><span>/</span><a href="/tasks">Tasks</a><span>/</span><span>Device workspace</span>
-            <span class="nav-actions">
+    <header class="topbar">
+        <div class="topbar-inner">
+            <div class="brand">
+                <a class="brand-name" href="/">iOS Farm</a>
+                <a class="brand-by" href="https://gethandler.ai" target="_blank" rel="noopener">by Handler</a>
+            </div>
+            <nav class="topbar-nav">
+                <a class="crumb" href="/">Devices</a>
+                <a class="crumb" href="/tasks">Tasks</a>
                 <button id="open-tasks" class="button secondary" type="button">Tasks &amp; schedules</button>
                 <button id="open-accounts" class="button secondary" type="button">Accounts</button>
                 <button id="open-passcode" class="button secondary" type="button">Passcode</button>
                 <button id="open-calibrate" class="button secondary" type="button">Touch points</button>
                 <button id="open-remove" class="button danger" type="button">Remove device</button>
                 __PLUGIN_NAV____AUTH_NAV__
-            </span>
-        </nav>
+            </nav>
+        </div>
+    </header>
+    <main class="shell device-shell" data-device-udid="__DEVICE_UDID__">
         <section id="device-summary" class="device-summary loading-card"
             hx-get="/api/devices/__DEVICE_UDID__/fragments/summary" hx-trigger="load" hx-swap="outerHTML">
             <span class="spinner" aria-hidden="true"></span>Loading device details…

--- a/static/dashboard/templates/index.html
+++ b/static/dashboard/templates/index.html
@@ -8,14 +8,22 @@
     <script src="/assets/htmx.min.js" defer></script>
 </head>
 <body>
+    <header class="topbar">
+        <div class="topbar-inner">
+            <div class="brand">
+                <a class="brand-name" href="/">iOS Farm</a>
+                <a class="brand-by" href="https://gethandler.ai" target="_blank" rel="noopener">by Handler</a>
+            </div>
+            <nav class="topbar-nav"><a class="button primary" href="/devices/register">Register device</a><a class="button secondary" href="/tasks">Tasks</a><button class="button secondary" type="button" hx-get="/api/fragments/devices" hx-target="#device-list" hx-swap="outerHTML">Refresh</button>__PLUGIN_NAV____AUTH_NAV__</nav>
+        </div>
+    </header>
     <main class="shell">
         <header class="page-header">
             <div>
-                <span class="eyebrow">Automation workspace · by Handler</span>
+                <span class="eyebrow">Automation workspace</span>
                 <h1>Devices</h1>
                 <p>Choose a connected iPhone to control it or run automation.</p>
             </div>
-            <div class="inline-actions"><a class="button primary" href="/devices/register">Register device</a><a class="button secondary" href="/tasks">Tasks</a><button class="button secondary" type="button" hx-get="/api/fragments/devices" hx-target="#device-list" hx-swap="outerHTML">Refresh</button>__PLUGIN_NAV____AUTH_NAV__</div>
         </header>
         <section id="device-list" class="device-list" hx-get="/api/fragments/devices" hx-trigger="load" hx-swap="outerHTML" aria-live="polite">
             <div class="loading-card"><span class="spinner" aria-hidden="true"></span>Looking for connected devices…</div>

--- a/static/dashboard/templates/register-device.html
+++ b/static/dashboard/templates/register-device.html
@@ -8,10 +8,18 @@
     <script type="module" src="/assets/register-device.js"></script>
 </head>
 <body>
+    <header class="topbar">
+        <div class="topbar-inner">
+            <div class="brand">
+                <a class="brand-name" href="/">iOS Farm</a>
+                <a class="brand-by" href="https://gethandler.ai" target="_blank" rel="noopener">by Handler</a>
+            </div>
+            <nav class="topbar-nav"><a class="button secondary" href="/">Back to devices</a>__PLUGIN_NAV____AUTH_NAV__</nav>
+        </div>
+    </header>
     <main class="shell registration-shell">
         <header class="page-header">
             <div><span class="eyebrow">Guided setup</span><h1>Register a device</h1><p>Keep the phone connected and unlocked. Every requirement is rechecked before it is saved.</p></div>
-            <a class="button secondary" href="/">Back to devices</a>__PLUGIN_NAV____AUTH_NAV__
         </header>
 
         <section class="registration-panel" id="candidate-panel">

--- a/static/dashboard/templates/tasks.html
+++ b/static/dashboard/templates/tasks.html
@@ -7,11 +7,18 @@
     <link rel="stylesheet" href="/assets/styles.css">
 </head>
 <body>
+    <header class="topbar">
+        <div class="topbar-inner">
+            <div class="brand">
+                <a class="brand-name" href="/">iOS Farm</a>
+                <a class="brand-by" href="https://gethandler.ai" target="_blank" rel="noopener">by Handler</a>
+            </div>
+            <nav class="topbar-nav"><a class="button secondary" href="/">Devices</a><button id="refresh-tasks" class="button secondary" type="button">Refresh</button>__PLUGIN_NAV____AUTH_NAV__</nav>
+        </div>
+    </header>
     <main class="shell">
-        <nav class="breadcrumb"><a href="/">Devices</a><span>/</span><span>Tasks</span>__PLUGIN_NAV____AUTH_NAV__</nav>
         <header class="page-header">
             <div><span class="eyebrow">Durable scheduler</span><h1>Tasks</h1><p>Upcoming schedules and execution history across every device.</p></div>
-            <button id="refresh-tasks" class="button secondary" type="button">Refresh</button>
         </header>
         <section class="panel task-section">
             <div class="section-heading"><div><span class="eyebrow">Queue</span><h2>Schedules</h2></div></div>


### PR DESCRIPTION
Subtle Handler branding on the open-source dashboard.

- New sticky, blurred top bar across all four templates (devices, device workspace, tasks, register) carrying an **iOS Farm** wordmark (links home) with a muted grey **by Handler** sub-line linking to gethandler.ai. Not accented, so it reads as Handler-built without pushing brand.
- Per-page nav buttons moved up into that bar; page-header eyebrows drop the old inline '· by Handler'.
- Footer: 'Built by Agniverse, with love and curry ❤️' → agniverse.co (overridable via PHONE_FARM_BRAND_URL).
- package-lock.json picks up one line syncing the license field.

`npm run check` passes locally (typecheck + 29 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)